### PR TITLE
Add chrome argument to chromedriver

### DIFF
--- a/scrape-youtube-channel-videos-url.py
+++ b/scrape-youtube-channel-videos-url.py
@@ -8,11 +8,14 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import InvalidArgumentException
+from selenium.webdriver.chrome.options import Options
 
 url = sys.argv[1]
 channelid = url.split('/')[4]
 #driver=webdriver.Firefox()
-driver=webdriver.Chrome()
+chrome_options = Options()
+chrome_options.add_argument("--user-data-dir=chrome-data")
+driver = webdriver.Chrome('chromedriver',options=chrome_options)
 driver.get(url)
 time.sleep(5)
 dt=datetime.datetime.now().strftime("%Y%m%d%H%M")


### PR DESCRIPTION
Youtube now comes with a cookie consent form. For this script to work you need to accept the consent screen. This commit adds the option to provide your own cookie files.

I had to do the following for this script to work:
```
chromium --user-data-dir=chrome-data
# accept the cookie consent form
```

A better solution would be to use chromedriver to press the consent form automatically.